### PR TITLE
create/renew certificates with tag if available

### DIFF
--- a/azlet/__main__.py
+++ b/azlet/__main__.py
@@ -14,8 +14,7 @@ def execute():
     parser.add_argument("--dns-resource-group", "-g", help="resource-group of the dns zone")
     parser.add_argument("--prefix", "-p", help="name of the certificate prefix (only for create operation)",
                         required=False)
-    parser.add_argument("--tags", "-t", help="tags of the certificate",
-                        required=False)
+    parser.add_argument("--tags", "-t", nargs="*", action = keyvalue, help="tags of the certificate", default=False)
     parser.add_argument("--force-creation",
                         action='store_true',
                         help="Try to create a new certificate even if a certificate already exists in the key vault",
@@ -58,6 +57,17 @@ def execute():
             bot.create(args.prefix, args.force_creation, args.tags)
         else:
             bot.create(args.prefix, args.force_creation)
+
+
+class keyvalue(argparse.Action):
+    def __call__( self , parser, namespace, values, option_string = None):
+        setattr(namespace, self.dest, dict())
+          
+        for value in values:
+            # split it into key and value
+            key, value = value.split('=')
+            # assign into dictionary
+            getattr(namespace, self.dest)[key] = value
 
 
 if __name__ == "__main__":

--- a/azlet/__main__.py
+++ b/azlet/__main__.py
@@ -12,7 +12,9 @@ def execute():
     parser.add_argument("--dns-zone", "-d", help="name of the dns-zone")
     parser.add_argument("--dns-subscription", "-s", help="subscription of the dns zone")
     parser.add_argument("--dns-resource-group", "-g", help="resource-group of the dns zone")
-    parser.add_argument("--prefix", "-p", help="name of the certificate prefix (only ofr create operation)",
+    parser.add_argument("--prefix", "-p", help="name of the certificate prefix (only for create operation)",
+                        required=False)
+    parser.add_argument("--tags", "-t", help="tags of the certificate",
                         required=False)
     parser.add_argument("--force-creation",
                         action='store_true',
@@ -52,7 +54,10 @@ def execute():
     if args.operation == "create":
         if not args.prefix:
             parser.error("--prefix is required for command 'create'")
-        bot.create(args.prefix, args.force_creation)
+        if args.tags:
+            bot.create(args.prefix, args.force_creation, args.tags)
+        else:
+            bot.create(args.prefix, args.force_creation)
 
 
 if __name__ == "__main__":

--- a/azlet/azertbot.py
+++ b/azlet/azertbot.py
@@ -83,10 +83,7 @@ class AzertBot:
         cert = client.get_certificate()
         key = client.cert_key
 
-        if tags:
-            self.store_pfx(domain_name, cert, key, tags)
-        else:
-            self.store_pfx(domain_name, cert, key)
+        self.store_pfx(domain_name, cert, key, tags)
 
     def check_exists(self, domain_name):
         name = clean_name(domain_name)
@@ -120,10 +117,7 @@ class AzertBot:
                 continue
             logging.info(f"Starting renewal ...")
 
-            if props.tags is not None:
-                self.create_certificate(domain_name=domain_name, tags=props.tags)
-            else:
-                self.create_certificate(domain_name=domain_name)
+            self.create_certificate(domain_name=domain_name, tags=props.tags)
 
     def rotate_domain(self, prefix: str):
         domain_name = prefix + '.' + self.dns_class.zone

--- a/azlet/azertbot.py
+++ b/azlet/azertbot.py
@@ -119,7 +119,11 @@ class AzertBot:
             if not str(domain_name).endswith(self.dns_class.zone):
                 continue
             logging.info(f"Starting renewal ...")
-            self.create_certificate(domain_name=domain_name)
+
+            if props.tags is not None:
+                self.create_certificate(domain_name=domain_name, tags=props.tags)
+            else:
+                self.create_certificate(domain_name=domain_name)
 
     def rotate_domain(self, prefix: str, tags=None):
         domain_name = prefix + '.' + self.dns_class.zone

--- a/azlet/azertbot.py
+++ b/azlet/azertbot.py
@@ -125,11 +125,13 @@ class AzertBot:
             else:
                 self.create_certificate(domain_name=domain_name)
 
-    def rotate_domain(self, prefix: str, tags=None):
+    def rotate_domain(self, prefix: str):
         domain_name = prefix + '.' + self.dns_class.zone
         name = clean_name(domain_name)
         try:
             cert = self.certificate_client.get_certificate(name)
-            self.create_certificate(domain_name, tags)
+            # is None or dict of tags
+            tags = cert.properties.tags
+            self.create_certificate(domain_name=domain_name, tags=tags)
         except:
             logging.error("Cannot find certificate to renew.")


### PR DESCRIPTION
- Die Zertifikate können mit tags erstellt/erneuert werden, wenn man welche mitliefert.
- Wurde mit der Klasse Azertbot() + DNS-Zone + KeyVault getestet