### PR TITLE
Added support for SANs 

### DIFF
--- a/azlet/__main__.py
+++ b/azlet/__main__.py
@@ -14,8 +14,8 @@ def execute():
     parser.add_argument("--dns-zone", "-d", help="name of the dns-zone")
     parser.add_argument("--dns-subscription", "-s", help="subscription of the dns zone")
     parser.add_argument("--dns-resource-group", "-g", help="resource-group of the dns zone")
-    parser.add_argument("--prefix", "-p", help="name of the certificate prefix (only for create operation) Use '@' to create a certificate for the root domain",
-                        required=False)
+    parser.add_argument("--prefix", "-p", help="name of the certificate prefix (only for create operation) Use '@' to create a certificate for the root domain. Can be supplied multiple times.",
+                        required=False, action='append' )
     parser.add_argument("--tags", "-t", nargs="*", action = keyvalue, help="tags of the certificate", default=False)
     parser.add_argument("--force-creation",
                         action='store_true',


### PR DESCRIPTION
You can now specify multiple `--prefix` options. The first one will become the subject.

`rotate` also keeps the SANs of the existing certificates on renewing